### PR TITLE
Removed Unnecessary Whitespace from Warning

### DIFF
--- a/src/@astro/internal/render.ts
+++ b/src/@astro/internal/render.ts
@@ -255,7 +255,7 @@ export function warnIfUsingExperimentalSSR(opts: LogOptions, config: AstroConfig
             opts,
             'warning',
             bold(`Warning:`),
-            ` SSR support is still experimental and subject to API changes. If using in production pin your dependencies to prevent accidental breakage.`
+            `SSR support is still experimental and subject to API changes. If using in production pin your dependencies to prevent accidental breakage.`
         );
     }
 }


### PR DESCRIPTION
Removed Unnecessary Whitespace from Warning when experimental SSR is enabled.